### PR TITLE
fixing Install to NAND for Cubian X on CubieTruck

### DIFF
--- a/cubian-nandinstall/usr/lib/cubian-nandinstall/install.sh
+++ b/cubian-nandinstall/usr/lib/cubian-nandinstall/install.sh
@@ -169,7 +169,7 @@ installBootloader(){
 rm -rf $MNT_BOOT/*
 rsync -avc $BOOTLOADER/* $MNT_BOOT
 rsync -avc /boot/script.bin /boot/uEnv.txt /boot/uImage* $MNT_ROOT/boot/
-sed -e 's|root=/dev/mmcblk0p1|root='$NAND_ROOT_DEVICE'|g' -i $MNT_ROOT/boot/uEnv.txt
+sed -e 's|root=/dev/mmcblk0p.|root='$NAND_ROOT_DEVICE'|g' -i $MNT_ROOT/boot/uEnv.txt
 if [[ "$DEVICE_TYPE" = "${DEVICE_A20}" ]];then
 	echo "machid=${MACH_ID}" >> $MNT_ROOT/boot/uEnv.txt
 fi


### PR DESCRIPTION
With latest Cubian X the install to NAND is not working anymore. It
seems that the SD card image has a different partition number for the
boot partition, therefore the sed statement does not find the correct
string to replace.
This change relaxes the search term a bit to find the boot partition on
any partition number.
It would be great if someone else could test if this change works for others.
Potentially solving issue #432 and issue #440
