### PR TITLE
cubian-nandinstall: Fixed problem in with symbolic link

### DIFF
--- a/cubian-nandinstall/usr/lib/cubian-nandinstall/install.sh
+++ b/cubian-nandinstall/usr/lib/cubian-nandinstall/install.sh
@@ -167,8 +167,8 @@ mount $NAND_ROOT_DEVICE $MNT_ROOT
 
 installBootloader(){
 rm -rf $MNT_BOOT/*
-rsync -avc $BOOTLOADER/* $MNT_BOOT
-rsync -avc /boot/script.bin /boot/uEnv.txt /boot/uImage* $MNT_ROOT/boot/
+rsync -avcL $BOOTLOADER/* $MNT_BOOT
+rsync -avcL /boot/script.bin /boot/uEnv.txt /boot/uImage* $MNT_ROOT/boot/
 sed -e 's|root=/dev/mmcblk0p1|root='$NAND_ROOT_DEVICE'|g' -i $MNT_ROOT/boot/uEnv.txt
 if [[ "$DEVICE_TYPE" = "${DEVICE_A20}" ]];then
 	echo "machid=${MACH_ID}" >> $MNT_ROOT/boot/uEnv.txt
@@ -177,7 +177,7 @@ fi
 
 installRootfs(){
 set +e
-rsync -avc --exclude-from=$EXCLUDE_FILE_LIST / $MNT_ROOT
+rsync -avcL --exclude-from=$EXCLUDE_FILE_LIST / $MNT_ROOT
 set -e
 echoBlue "sync disk... please wait"
 sync


### PR DESCRIPTION
I tried use cubian-nandinstall but it was with problem when copy uEnv.txt, checking it I saw that my uEnv.txt was a symbolic link, but the command that was try coping it (rsync) can't copy symbolic linc without an option.
To fix the issue I just add L option to all rsync command in script.

Simulated error bellow:

root@Cubian:/home/cubie# cubian-nandinstall 

 #    #   ##   #####  #    # # #    #  ####  
 #    #  #  #  #    # ##   # # ##   # #    # 
 #    # #    # #    # # #  # # # #  # #  
 # ## # ###### #####  #  # # # #  # # #  ### 
 ##  ## #    # #   #  #   ## # #   ## #    # 
 #    # #    # #    # #    # # #    #  ####  

Your data on /dev/nand will lost, Are you sure to continue?[y/n] y
Re-partitioning NAND device
check partition table copy 0: mbr: version 0x00000200, magic softw411
OK
check partition table copy 1: mbr: version 0x00000200, magic softw411
OK
check partition table copy 2: mbr: version 0x00000200, magic softw411
OK
check partition table copy 3: mbr: version 0x00000200, magic softw411
OK
mbr: version 0x00000200, magic softw411
2 partitions
partition  1: class =         DISK, name =   bootloader, partition start =      128, partition size =     2048 user_type=0
partition  2: class =         DISK, name =        linux, partition start =     2176, partition size =        0 user_type=0
check partition table copy 0: mbr: version 0x00000200, magic softw411
check partition table copy 1: mbr: version 0x00000200, magic softw411
check partition table copy 2: mbr: version 0x00000200, magic softw411
check partition table copy 3: mbr: version 0x00000200, magic softw411

ready to write new partition tables:
mbr: version 0x00000200, magic softw411
2 partitions
partition  1: class =         DISK, name =   bootloader, partition start =      128, partition size =     2048 user_type=0
partition  2: class =         DISK, name =        linux, partition start =     2176, partition size =        0 user_type=0

write new partition tables? (Y/N)

verifying new partition tables:
check partition table copy 0: mbr: version 0x00000200, magic softw411
OK
check partition table copy 1: mbr: version 0x00000200, magic softw411
OK
check partition table copy 2: mbr: version 0x00000200, magic softw411
OK
check partition table copy 3: mbr: version 0x00000200, magic softw411
OK
mbr: version 0x00000200, magic softw411
2 partitions
partition  1: class =         DISK, name =   bootloader, partition start =      128, partition size =     2048 user_type=0
partition  2: class =         DISK, name =        linux, partition start =     2176, partition size =        0 user_type=0
rereading partition table... returned 0
Check partition table
Formating NAND devices
mke2fs 1.42.5 (29-Jul-2012)
Mount NAND partitions
/dev/nanda on /mnt/nanda type vfat (rw,relatime,fmask=0022,dmask=0022,codepage=cp437,iocharset=ascii,shortname=mixed,errors=remount-ro)
/dev/nandb on /mnt/nandb type ext4 (rw,relatime,data=ordered)
Install and configure bootloader
sending incremental file list
boot.axf
boot.ini
linux/
linux/linux.ini
linux/u-boot.bin

sent 428782 bytes  received 92 bytes  857748.00 bytes/sec
total size is 428383  speedup is 1.00
sending incremental file list
created directory /mnt/nandb/boot
script.bin -> script.bin.dir/cubieboard2_argon.bin
uEnv.txt -> uEnv.dir/uEnv.txt
uImage -> uImage.dir/uImage
uImage.dir/
uImage.dir/uImage
uImage.dir/uImage.orig
uImage.dir/uImage.vsync

sent 17893518 bytes  received 82 bytes  7157440.00 bytes/sec
total size is 17891006  speedup is 1.00
sed: can't read /mnt/nandb/boot/uEnv.txt: No such file or directory
root@Cubian:/home/cubie# 

root@Cubian:/home/cubie# cat /etc/debian_version 
7.1
root@Cubian:/home/cubie# cat /etc/issue
Debian GNU/Linux 7 \n \l
root@Cubian:/home/cubie# 
root@Cubian:/home/cubie# uname -a
Linux Cubian 3.4.79-sun7i #1 SMP PREEMPT Thu Jun 12 17:27:11 WEST 2014 armv7l GNU/Linux
root@Cubian:/home/cubie#
